### PR TITLE
bug(changes-admin): changes to admin

### DIFF
--- a/UI/pages/admin.html
+++ b/UI/pages/admin.html
@@ -11,15 +11,7 @@
         <header style="height: 160px;">
             <nav>
                 <div class="row clearfix">
-                        <div class="logo"><span>B</span>road<span1>C</span1>aster</div>
-                 <ul class="main-nav animated slideInDown" id="check-class">
-                     <li><a href="../pages/index.html">Home</a></li>
-                     <li><a href="../pages/login-2.html">Admin</a></li>
-                     <li><a href="../pages/login.html">Sign In</a></li>
-                     <li><a href="../pages/sign up.html">Sign Up</a></li>
-                     <li><a href="../pages/contact.html">Contact</a></li>
-                 </ul>
-                 <a href="#" class="mobile-icon" onclick="slideshow()">Menu</a>
+                   <a href="../pages/index.html"><div class="logo"><span>B</span>road<span1>C</span1>aster</div></a>
                 </div>
             </nav>
         

--- a/UI/pages/contact.html
+++ b/UI/pages/contact.html
@@ -13,7 +13,6 @@
                         <div class="logo"><span>B</span>road<span1>C</span1>aster</div>
                  <ul class="main-nav animated slideInDown" id="check-class">
                      <li><a href="../pages/index.html">Home</a></li>
-                     <li><a href="../pages/login-2.html">Admin</a></li>
                      <li><a href="../pages/login.html">Sign In</a></li>
                      <li><a href="../pages/sign up.html">Sign Up</a></li>
                      <li><a href="../pages/contact.html">Contact Us</a></li>

--- a/UI/pages/list2.html
+++ b/UI/pages/list2.html
@@ -14,9 +14,6 @@
                         <div class="logo"><span>B</span>road<span1>C</span1>aster</div>
                  <ul class="main-nav animated slideInDown" id="check-class">
                      <li><a href="../pages/index.html">Home</a></li>
-                     <li><a href="../pages/login-2.html">Admin</a></li>
-                     <li><a href="../pages/login.html">Sign In</a></li>
-                     <li><a href="../pages/sign up.html">Sign Up</a></li>
                      <li><a href="../pages/contact.html">Contact</a></li>
                  </ul>
                  <a href="#" class="mobile-icon" onclick="slideshow()">Menu</a>

--- a/UI/pages/login-2.html
+++ b/UI/pages/login-2.html
@@ -10,15 +10,8 @@
         <header>
             <nav>
                 <div class="row clearfix">
-                        <div class="logo"><span>B</span>road<span1>C</span1>aster</div>
-                 <ul class="main-nav animated slideInDown" id="check-class">
-                     <li><a href="../pages/index.html">Home</a></li>
-                     <li><a href="../pages/login-2.html">Admin</a></li>
-                     <li><a href="../pages/login.html">Sign In</a></li>
-                     <li><a href="../pages/sign up.html">Sign Up</a></li>
-                     <li><a href="../pages/contact.html">Contact</a></li>
-                 </ul>
-                 <a href="#" class="mobile-icon" onclick="slideshow()">Menu</a>
+                  <a href="../pages/index.html"><div class="logo"><span>B</span>road<span1>C</span1>aster</div></a>
+                
                 </div>
             </nav>
             <div class="login-box">

--- a/UI/pages/login.html
+++ b/UI/pages/login.html
@@ -13,7 +13,6 @@
                         <div class="logo"><span>B</span>road<span1>C</span1>aster</div>
                  <ul class="main-nav animated slideInDown" id="check-class">
                      <li><a href="../pages/index.html">Home</a></li>
-                     <li><a href="../pages/login-2.html">Admin</a></li>
                      <li><a href="../pages/login.html">Sign In</a></li>
                      <li><a href="../pages/sign up.html">Sign Up</a></li>
                      <li><a href="../pages/contact.html">Contact</a></li>

--- a/UI/pages/sign up.html
+++ b/UI/pages/sign up.html
@@ -13,7 +13,6 @@
                         <div class="logo"><span>B</span>road<span1>C</span1>aster</div>
                  <ul class="main-nav animated slideInDown" id="check-class">
                      <li><a href="../pages/index.html">Home</a></li>
-                     <li><a href="../pages/login-2.html">Admin</a></li>
                      <li><a href="../pages/login.html">Sign In</a></li>
                      <li><a href="../pages/sign up.html">Sign Up</a></li>
                      <li><a href="../pages/contact.html">Contact</a></li>


### PR DESCRIPTION
An admin should not see anything on the header unless logo and the button on the left side

[finishes:##169764008]
#### What does this PR do?
- This will show an admin nothing on the header unless logo and even to other pages related to admin
#### Description of Task to be completed?
- the header, the body with the table and the button on the left side
#### How should this be manually tested?
- This should be tested using any browser
#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
-  https://www.pivotaltracker.com/story/show/169764008
#### Screenshots (if appropriate)
- ![adm](https://user-images.githubusercontent.com/55635977/68888352-749e4280-0723-11ea-8a3a-3bf35ce356da.JPG)

#### Questions:
